### PR TITLE
fix: Address Qodo-Merge-Pro feedback on serialization and test infrastructure

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,7 +20,8 @@ addopts =
     -v
     --tb=short
     --strict-markers
+    -m "not integration"
 
-# Skip integration tests by default
+# Skip integration tests by default (configured in addopts above)
 # Run integration tests explicitly with: pytest -m integration
 # Or run everything with: pytest -m ""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,26 @@
+[pytest]
+# Pytest configuration for DataAgent tests
+
+# Custom markers
+markers =
+    integration: marks tests as integration tests requiring external dependencies (LLM APIs, databases, model downloads)
+    unit: marks tests as unit tests that can run without external dependencies
+    contract: marks tests as contract validation tests
+
+# Test discovery patterns
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+# Default test path
+testpaths = tests
+
+# Output options
+addopts = 
+    -v
+    --tb=short
+    --strict-markers
+
+# Skip integration tests by default
+# Run integration tests explicitly with: pytest -m integration
+# Or run everything with: pytest -m ""

--- a/tests/integration/test_memory_integration.py
+++ b/tests/integration/test_memory_integration.py
@@ -3,7 +3,8 @@
 Tests recipe storage and retrieval end-to-end workflows.
 
 NOTE: These tests require sentence-transformers model downloads and may have network dependencies.
-They are currently skipped pending proper test infrastructure setup.
+Run with: pytest -m integration
+Skip with: pytest -m "not integration"
 """
 
 import tempfile
@@ -18,7 +19,7 @@ from lib.agents.data_agent.memory import (
 )
 
 
-pytestmark = pytest.mark.skip(reason="Integration tests require model downloads and network access")
+pytestmark = pytest.mark.integration
 
 
 class TestMemoryLayerIntegration:

--- a/tests/integration/test_recipe_reuse.py
+++ b/tests/integration/test_recipe_reuse.py
@@ -69,16 +69,17 @@ class TestRecipeReuse:
         print(f"Response artifacts: {len(response.artifacts)}")
         print(f"Response summary: {response.summary}")
         
-        # Assert status with additional verification
-        assert response.status in ["completed", "partial_success"], f"Unexpected status: {response.status}"
+        # Assert status with additional verification using enum
+        from lib.agents.data_agent.agent import AnalysisStatus
+        assert response.status in [AnalysisStatus.SUCCESS, AnalysisStatus.PARTIAL], f"Unexpected status: {response.status}"
         
         # For completed status, verify artifacts exist
-        if response.status == "completed":
-            assert len(response.artifacts) > 0, "Completed status requires artifacts"
+        if response.status == AnalysisStatus.SUCCESS:
+            assert len(response.artifacts) > 0, "Success status requires artifacts"
         
         # For partial_success, verify error is documented
-        if response.status == "partial_success":
-            assert response.error is not None, "Partial success requires error documentation"
+        if response.status == AnalysisStatus.PARTIAL:
+            assert response.error_message is not None, "Partial success requires error documentation"
 
     def test_recipe_retrieval_by_schema_and_intent(self, data_agent, sample_request):
         """FR-032: Retrieve recipe by schema fingerprint + intent similarity."""

--- a/tests/integration/test_recipe_reuse.py
+++ b/tests/integration/test_recipe_reuse.py
@@ -4,7 +4,8 @@ Integration test for recipe storage and retrieval functionality.
 Tests FR-031 to FR-033: Recipe memory for successful analysis patterns.
 
 NOTE: These tests require LLM API keys and/or database connections to function properly.
-They are currently skipped pending proper test infrastructure setup.
+Run with: pytest -m integration
+Skip with: pytest -m "not integration"
 """
 
 import pytest
@@ -12,7 +13,7 @@ from lib.agents.data_agent.agent import DataAgent
 from lib.agents.data_agent.contracts.request import AnalysisRequest
 
 
-pytestmark = pytest.mark.skip(reason="Integration tests require LLM API and database setup")
+pytestmark = pytest.mark.integration
 
 
 @pytest.fixture
@@ -68,7 +69,16 @@ class TestRecipeReuse:
         print(f"Response artifacts: {len(response.artifacts)}")
         print(f"Response summary: {response.summary}")
         
-        assert response.status == "completed" or response.status == "partial_success"
+        # Assert status with additional verification
+        assert response.status in ["completed", "partial_success"], f"Unexpected status: {response.status}"
+        
+        # For completed status, verify artifacts exist
+        if response.status == "completed":
+            assert len(response.artifacts) > 0, "Completed status requires artifacts"
+        
+        # For partial_success, verify error is documented
+        if response.status == "partial_success":
+            assert response.error is not None, "Partial success requires error documentation"
 
     def test_recipe_retrieval_by_schema_and_intent(self, data_agent, sample_request):
         """FR-032: Retrieve recipe by schema fingerprint + intent similarity."""


### PR DESCRIPTION
### **User description**
## Summary
Addresses automated code review feedback from Qodo-Merge-Pro on PR #11.

## Changes

### 1. Enhanced Serialization Robustness (agent.py:138-152)
- Added `dataclasses.asdict()` support for dataclass objects
- Prevents `TypeError` when audit logging non-Pydantic objects
- Handles three types: Pydantic models, dataclasses, and plain dicts

**Before:**
```python
data_sources=[ds.model_dump() if hasattr(ds, 'model_dump') else ds for ds in request.data_sources]
```

**After:**
```python
serialized_data_sources = []
for ds in request.data_sources:
    if hasattr(ds, 'model_dump'):
        serialized_data_sources.append(ds.model_dump())
    elif dataclasses.is_dataclass(ds) and not isinstance(ds, type):
        serialized_data_sources.append(dataclasses.asdict(ds))
    else:
        serialized_data_sources.append(ds)
```

### 2. Test Infrastructure Improvements
- Changed from `pytest.mark.skip` to `pytest.mark.integration`
- Added `pytest.ini` with custom markers (integration, unit, contract)
- Integration tests now run conditionally instead of being disabled

**Usage:**
```bash
# Run integration tests explicitly
pytest -m integration

# Skip integration tests (default)
pytest -m "not integration"

# Run specific test types
pytest -m unit
pytest -m contract
```

### 3. Test Signal Clarity (test_recipe_reuse.py:72-81)
- Enhanced assertions for status validation
- Verify artifacts exist for "completed" status
- Verify error documentation for "partial_success" status

**Before:**
```python
assert response.status == "completed" or response.status == "partial_success"
```

**After:**
```python
assert response.status in ["completed", "partial_success"], f"Unexpected status: {response.status}"

if response.status == "completed":
    assert len(response.artifacts) > 0, "Completed status requires artifacts"

if response.status == "partial_success":
    assert response.error is not None, "Partial success requires error documentation"
```

## Qodo Feedback Addressed
- ✅ Serialization Robustness (Medium Impact)
- ✅ Test suite disabling (Medium Impact)  
- ✅ Test Signal Clarity

## Test Plan
- [x] Unit tests pass: `pytest tests/unit/ -v`
- [x] Contract tests pass: `pytest tests/contract/ -v`
- [x] Integration tests properly marked: `pytest --collect-only -m integration`
- [x] pytest.ini markers registered correctly

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enhanced serialization robustness for dataclass objects in audit logging

- Improved test infrastructure with proper pytest markers and configuration

- Added better test assertions for status validation

- Replaced test skipping with conditional integration test execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Serialization Fix"] --> B["Enhanced audit logging"]
  C["Test Infrastructure"] --> D["pytest.ini configuration"]
  C --> E["Integration test markers"]
  F["Test Assertions"] --> G["Status validation improvements"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.py</strong><dd><code>Enhanced serialization robustness for audit logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/agents/data_agent/agent.py

<ul><li>Added <code>dataclasses</code> import for enhanced serialization support<br> <li> Implemented robust serialization logic for Pydantic models, <br>dataclasses, and plain dicts<br> <li> Prevents <code>TypeError</code> when audit logging non-Pydantic objects</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/multi-agent-system/pull/12/files#diff-f5f8ba88017058815e5118b4acd4cc2dbb8b2139f9fb72c3cd9215532a4fe188">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_memory_integration.py</strong><dd><code>Convert skipped tests to integration markers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_memory_integration.py

<ul><li>Replaced <code>pytest.mark.skip</code> with <code>pytest.mark.integration</code><br> <li> Updated docstring with proper test execution instructions<br> <li> Enabled conditional test execution instead of permanent skipping</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/multi-agent-system/pull/12/files#diff-3f639fc975033c2cfdafcb29d3657b16645d5c5d86f92cf0c561dcf77187d7fa">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_recipe_reuse.py</strong><dd><code>Improved test assertions and integration markers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_recipe_reuse.py

<ul><li>Replaced <code>pytest.mark.skip</code> with <code>pytest.mark.integration</code><br> <li> Enhanced status assertions with specific validation logic<br> <li> Added verification for artifacts on completed status<br> <li> Added error documentation check for partial_success status</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/multi-agent-system/pull/12/files#diff-b890b645e715e2fc93c82695de009c29e0ab769af6f172ad55ae9910f68e2c7d">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pytest.ini</strong><dd><code>Added pytest configuration with custom markers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pytest.ini

<ul><li>Added custom pytest markers for integration, unit, and contract tests<br> <li> Configured test discovery patterns and output options<br> <li> Set default behavior to skip integration tests unless explicitly <br>requested</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/multi-agent-system/pull/12/files#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

